### PR TITLE
Issue 177

### DIFF
--- a/src/components/CountryDropDown.tsx
+++ b/src/components/CountryDropDown.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import React from 'react';
+import { Form } from 'react-bootstrap';
+import { UseFormRegister } from 'react-hook-form';
+import { Country } from '@prisma/client'; // Update the path as needed
+
+const displayNames: Record<Country, string> = {
+  [Country.USA]: 'United States',
+  [Country.CAN]: 'Canada',
+};
+
+// Helper function to get display name for country
+const getCountryDisplayName = (country: Country): string => {
+  return displayNames[country];
+};
+
+export interface ICountryField {
+  country: Country;
+}
+
+export interface CountryDropDownProps {
+  register: UseFormRegister<ICountryField>;
+  errors: { country?: { message?: string } };
+  disabled?: boolean;
+}
+
+const CountryDropDown = ({ register, errors, disabled }: CountryDropDownProps) => (
+  <>
+    <Form.Select
+      id="country"
+      size="lg"
+      as="select"
+      aria-label="Country"
+      {...register('country')}
+      disabled={disabled}
+      isInvalid={!!errors.country}
+      defaultValue={Country.USA}
+    >
+      {
+        Object.values(Country).map((country) => (
+          <option key={country} value={country}>
+            {getCountryDisplayName(country)}
+          </option>
+        ))
+      }
+    </Form.Select>
+    <Form.Control.Feedback type="invalid">
+      {errors.country?.message}
+    </Form.Control.Feedback>
+  </>
+);
+
+export default CountryDropDown;

--- a/src/components/CountryDropDown.tsx
+++ b/src/components/CountryDropDown.tsx
@@ -11,9 +11,9 @@ const displayNames: Record<Country, string> = {
 };
 
 // Helper function to get display name for country
-const getCountryDisplayName = (country: Country): string => {
-  return displayNames[country];
-};
+const getCountryDisplayName = (country: Country): string => (
+  displayNames[country]
+);
 
 export interface ICountryField {
   country: Country;

--- a/src/components/CountryDropDown.tsx
+++ b/src/components/CountryDropDown.tsx
@@ -30,7 +30,6 @@ const CountryDropDown = ({ register, errors, disabled }: CountryDropDownProps) =
     <Form.Select
       id="country"
       size="lg"
-      as="select"
       aria-label="Country"
       {...register('country')}
       disabled={disabled}

--- a/src/components/CountryDropDown.tsx
+++ b/src/components/CountryDropDown.tsx
@@ -12,7 +12,7 @@ const displayNames: Record<Country, string> = {
 
 // Helper function to get display name for country
 const getCountryDisplayName = (country: Country): string => (
-  displayNames[country]
+  displayNames[country] ?? country
 );
 
 export interface ICountryField {


### PR DESCRIPTION
This pull request introduces a new `CountryDropDown` component for selecting a country in forms, using React, React Bootstrap, and React Hook Form. The component provides a user-friendly dropdown with display names for countries and integrates validation feedback.

New component implementation:

* Added the `CountryDropDown` component in `src/components/CountryDropDown.tsx`, supporting country selection with display names and form validation.
* Defined a mapping (`displayNames`) to show user-friendly names for each `Country` enum value.
* Integrated React Hook Form registration and validation error handling for the country field.
* Used Bootstrap's `Form.Select` for the dropdown UI and provided an invalid feedback message when there are validation errors.Add Country Dropdown Component to allow users to select Country Code when editing an Address.
closes #177