### PR TITLE
Issue 178

### DIFF
--- a/src/components/AddressSubForm.tsx
+++ b/src/components/AddressSubForm.tsx
@@ -71,6 +71,7 @@ const AddressSubForm = ({ register, errors, onEdit, address }: AddressSubFormPro
       </Container>
     );
   }
+
   return (
     <Container>
       <Row>
@@ -84,6 +85,9 @@ const AddressSubForm = ({ register, errors, onEdit, address }: AddressSubFormPro
               size="lg"
               isInvalid={!!errors.address1}
               {...register('address1')}
+              defaultValue={address.address1}
+              value={editAddress.address1}
+              onChange={(e) => setEditAddress({ ...editAddress, address1: e.target.value })}
             />
             <Form.Control.Feedback type="invalid">
               {errors.address1?.message}
@@ -124,6 +128,9 @@ const AddressSubForm = ({ register, errors, onEdit, address }: AddressSubFormPro
               size="lg"
               isInvalid={!!errors.address2}
               {...register('address2')}
+              defaultValue={address.address2}
+              value={editAddress.address2}
+              onChange={(e) => setEditAddress({ ...editAddress, address2: e.target.value })}
             />
             <Form.Control.Feedback type="invalid">
               {errors.address2?.message}
@@ -142,6 +149,9 @@ const AddressSubForm = ({ register, errors, onEdit, address }: AddressSubFormPro
               size="lg"
               isInvalid={!!errors.city}
               {...register('city')}
+              defaultValue={address.city}
+              value={editAddress.city}
+              onChange={(e) => setEditAddress({ ...editAddress, city: e.target.value })}
             />
             <Form.Control.Feedback type="invalid">
               {errors.city?.message}
@@ -158,6 +168,9 @@ const AddressSubForm = ({ register, errors, onEdit, address }: AddressSubFormPro
               size="lg"
               isInvalid={!!errors.state}
               {...register('state')}
+              defaultValue={address.state}
+              value={editAddress.state}
+              onChange={(e) => setEditAddress({ ...editAddress, state: e.target.value })}
             />
             <Form.Control.Feedback type="invalid">
               {errors.state?.message}
@@ -174,6 +187,9 @@ const AddressSubForm = ({ register, errors, onEdit, address }: AddressSubFormPro
               size="lg"
               isInvalid={!!errors.zipcode}
               {...register('zipcode')}
+              defaultValue={address.zipcode}
+              value={editAddress.zipcode}
+              onChange={(e) => setEditAddress({ ...editAddress, zipcode: e.target.value })}
             />
             <Form.Control.Feedback type="invalid">
               {errors.zipcode?.message}

--- a/src/components/AddressSubForm.tsx
+++ b/src/components/AddressSubForm.tsx
@@ -185,8 +185,8 @@ const AddressSubForm = ({ register, errors, onEdit, address }: AddressSubFormPro
       <Row>
         <Col md={4}>
           <CountryDropDown
-            register={register('country') as unknown as UseFormRegister<ICountryField>}
-            errors={errors as unknown as { [key in keyof ICountryField]?: { message?: string } }}
+            register={register('country')}
+            errors={{ country: errors.country }}
           />
         </Col>
       </Row>

--- a/src/components/AddressSubForm.tsx
+++ b/src/components/AddressSubForm.tsx
@@ -37,7 +37,7 @@ const AddressSubForm = ({ register, errors, onEdit, address }: AddressSubFormPro
   };
 
   const handleCancelClick = () => {
-    setEditAddress(editAddress);
+    setEditAddress(address);
     setIsEditing(false);
   };
 

--- a/src/components/AddressSubForm.tsx
+++ b/src/components/AddressSubForm.tsx
@@ -46,16 +46,16 @@ const AddressSubForm = ({ register, errors, onEdit, address }: AddressSubFormPro
       <Container>
         <Row className="mb-3">
           <Col>
-            <p className="fw-bold">{editAddress.address1 || 'No Address Provided'}</p>
-            <p className="mb-1">{editAddress.address2}</p>
+            <p className="fw-bold">{address.address1 || 'No Address Provided'}</p>
+            <p className="mb-1">{address.address2}</p>
             <p className="mb-1">
-              {editAddress.city}
+              {address.city}
               {', '}
-              {editAddress.state}
+              {address.state}
               {' '}
-              {editAddress.zipcode}
+              {address.zipcode}
             </p>
-            <p className="mb-0">{editAddress.country}</p>
+            <p className="mb-0">{address.country}</p>
           </Col>
           <Col>
             <Button

--- a/src/components/AddressSubForm.tsx
+++ b/src/components/AddressSubForm.tsx
@@ -5,7 +5,6 @@ import { Button, Col, Container, Form, Row } from 'react-bootstrap';
 import { UseFormRegister } from 'react-hook-form';
 import CountryDropDown, { ICountryField } from '@/components/CountryDropDown';
 import { Check, Pencil, X } from 'react-bootstrap-icons';
-import { Country } from '@prisma/client';
 
 export interface IAddressSubForm extends ICountryField {
   address1: string;
@@ -185,7 +184,7 @@ const AddressSubForm = ({ register, errors, onEdit, address }: AddressSubFormPro
       <Row>
         <Col md={4}>
           <CountryDropDown
-            register={register('country')}
+            register={register('country') as unknown as UseFormRegister<ICountryField>}
             errors={{ country: errors.country }}
           />
         </Col>

--- a/src/components/AddressSubForm.tsx
+++ b/src/components/AddressSubForm.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import { Country } from '@prisma/client';
-import React from 'react';
-import { Col, Container, Form, Row } from 'react-bootstrap';
+import React, { useState } from 'react';
+import { Button, Col, Container, Form, Row } from 'react-bootstrap';
 import { UseFormRegister } from 'react-hook-form';
 import CountryDropDown, { ICountryField } from '@/components/CountryDropDown';
+import { Check, Pencil, X } from 'react-bootstrap-icons';
+import { Country } from '@prisma/client';
 
 export interface IAddressSubForm extends ICountryField {
   address1: string;
@@ -17,105 +18,186 @@ export interface IAddressSubForm extends ICountryField {
 interface AddressSubFormProps {
   register: UseFormRegister<IAddressSubForm>;
   errors: { [key in keyof IAddressSubForm]?: { message?: string } };
+  onEdit: (data: IAddressSubForm) => void;
 }
 
-const AddressSubForm = ({ register, errors }: AddressSubFormProps) => (
-  <Container>
-    <Row>
-      <Col md={6}>
-        <Form.Group controlId="address1">
-          <Form.Label aria-required="true">Address 1: *</Form.Label>
-          <Form.Control
-            id="address1"
-            type="text"
-            placeholder={'Address 1'}
-            size="lg"
-            isInvalid={!!errors.address1}
-            {...register('address1')}
+const AddressSubForm = ({ register, errors, onEdit }: AddressSubFormProps) => {
+  const [isEditing, setIsEditing] = useState(false);
+  const [editAddress, setEditAddress] = useState<IAddressSubForm>({
+    address1: '',
+    address2: '',
+    city: '',
+    state: '',
+    zipcode: '',
+    country: Country.USA,
+  });
+
+  const handleEditClick = () => {
+    setIsEditing(true);
+    setEditAddress(register as unknown as IAddressSubForm);
+  };
+
+  const handleSaveClick = () => {
+    onEdit(editAddress);
+    setIsEditing(false);
+  };
+
+  const handleCancelClick = () => {
+    setEditAddress(editAddress);
+    setIsEditing(false);
+  };
+
+  if (!isEditing) {
+    return (
+      <Container>
+        <Row className="mb-3">
+          <Col>
+            <p className="fw-bold">{editAddress.address1 || 'No Address Provided'}</p>
+            <p className="mb-1">{editAddress.address2}</p>
+            <p className="mb-1">
+              {editAddress.city}
+              {', '}
+              {editAddress.state}
+              {' '}
+              {editAddress.zipcode}
+            </p>
+            <p className="mb-0">{editAddress.country}</p>
+          </Col>
+          <Col>
+            <Button
+              variant="outline-dark"
+              size="sm"
+              className="me-2 p-1"
+              aria-label="Edit Address"
+              onClick={handleEditClick}
+            >
+              <Pencil />
+            </Button>
+          </Col>
+        </Row>
+      </Container>
+    );
+  }
+  return (
+    <Container>
+      <Row>
+        <Col md={6}>
+          <Form.Group controlId="address1">
+            <Form.Label aria-required="true">Address 1: *</Form.Label>
+            <Form.Control
+              id="address1"
+              type="text"
+              placeholder="Address 1"
+              size="lg"
+              isInvalid={!!errors.address1}
+              {...register('address1')}
+            />
+            <Form.Control.Feedback type="invalid">
+              {errors.address1?.message}
+            </Form.Control.Feedback>
+          </Form.Group>
+        </Col>
+        <Col md={6} className="d-flex align-items-end mb-3">
+          <span className="me-auto">
+            <Button
+              variant="success"
+              size="sm"
+              className="me-2 p-1"
+              aria-label="Save Address"
+              onClick={handleSaveClick}
+            >
+              <Check />
+            </Button>
+            <Button
+              variant="danger"
+              size="sm"
+              className="p-1"
+              aria-label="Cancel editing"
+              onClick={handleCancelClick}
+            >
+              <X />
+            </Button>
+          </span>
+        </Col>
+      </Row>
+      <Row>
+        <Col md={6}>
+          <Form.Group controlId="address2">
+            <Form.Label>Address 2:</Form.Label>
+            <Form.Control
+              id="address2"
+              type="text"
+              placeholder="Address 2"
+              size="lg"
+              isInvalid={!!errors.address2}
+              {...register('address2')}
+            />
+            <Form.Control.Feedback type="invalid">
+              {errors.address2?.message}
+            </Form.Control.Feedback>
+          </Form.Group>
+        </Col>
+      </Row>
+      <Row>
+        <Col md={4}>
+          <Form.Group controlId="city">
+            <Form.Label>City:</Form.Label>
+            <Form.Control
+              id="city"
+              type="text"
+              placeholder="City"
+              size="lg"
+              isInvalid={!!errors.city}
+              {...register('city')}
+            />
+            <Form.Control.Feedback type="invalid">
+              {errors.city?.message}
+            </Form.Control.Feedback>
+          </Form.Group>
+        </Col>
+        <Col md={4}>
+          <Form.Group controlId="state">
+            <Form.Label>State:</Form.Label>
+            <Form.Control
+              id="state"
+              type="text"
+              placeholder="State"
+              size="lg"
+              isInvalid={!!errors.state}
+              {...register('state')}
+            />
+            <Form.Control.Feedback type="invalid">
+              {errors.state?.message}
+            </Form.Control.Feedback>
+          </Form.Group>
+        </Col>
+        <Col md={4}>
+          <Form.Group controlId="zipcode">
+            <Form.Label>Zipcode:</Form.Label>
+            <Form.Control
+              id="zipcode"
+              type="text"
+              placeholder="Zipcode"
+              size="lg"
+              isInvalid={!!errors.zipcode}
+              {...register('zipcode')}
+            />
+            <Form.Control.Feedback type="invalid">
+              {errors.zipcode?.message}
+            </Form.Control.Feedback>
+          </Form.Group>
+        </Col>
+      </Row>
+      <Row>
+        <Col md={4}>
+          <CountryDropDown
+            register={register('country') as unknown as UseFormRegister<ICountryField>}
+            errors={errors as unknown as { [key in keyof ICountryField]?: { message?: string } }}
           />
-          <Form.Control.Feedback type="invalid">
-            {errors.address1?.message}
-          </Form.Control.Feedback>
-        </Form.Group>
-      </Col>
-    </Row>
-    <Row>
-      <Col md={6}>
-        <Form.Group controlId="address2">
-          <Form.Label>Address 2:</Form.Label>
-          <Form.Control
-            id="address2"
-            type="text"
-            placeholder={'Address 2'}
-            size="lg"
-            isInvalid={!!errors.address2}
-            {...register('address2')}
-          />
-          <Form.Control.Feedback type="invalid">
-            {errors.address2?.message}
-          </Form.Control.Feedback>
-        </Form.Group>
-      </Col>
-    </Row>
-    <Row>
-      <Col md={4}>
-        <Form.Group controlId="city">
-          <Form.Label>City:</Form.Label>
-          <Form.Control
-            id="city"
-            type="text"
-            placeholder={'City'}
-            size="lg"
-            isInvalid={!!errors.city}
-            {...register('city')}
-          />
-          <Form.Control.Feedback type="invalid">
-            {errors.city?.message}
-          </Form.Control.Feedback>
-        </Form.Group>
-      </Col>
-      <Col md={4}>
-        <Form.Group controlId="state">
-          <Form.Label>State:</Form.Label>
-          <Form.Control
-            id="state"
-            type="text"
-            placeholder={'State'}
-            size="lg"
-            isInvalid={!!errors.state}
-            {...register('state')}
-          />
-          <Form.Control.Feedback type="invalid">
-            {errors.state?.message}
-          </Form.Control.Feedback>
-        </Form.Group>
-      </Col>
-      <Col md={4}>
-        <Form.Group controlId="zipcode">
-          <Form.Label>Zipcode:</Form.Label>
-          <Form.Control
-            id="zipcode"
-            type="text"
-            placeholder={'Zipcode'}
-            size="lg"
-            isInvalid={!!errors.zipcode}
-            {...register('zipcode')}
-          />
-          <Form.Control.Feedback type="invalid">
-            {errors.zipcode?.message}
-          </Form.Control.Feedback>
-        </Form.Group>
-      </Col>
-    </Row>
-    <Row>
-      <Col md={4}>
-        <CountryDropDown
-          register={register('country') as unknown as UseFormRegister<ICountryField>}
-          errors={errors as unknown as { [key in keyof ICountryField]?: { message?: string } }}
-        />
-      </Col>
-    </Row>
-  </Container>
-);
+        </Col>
+      </Row>
+    </Container>
+  );
+};
 
 export default AddressSubForm;

--- a/src/components/AddressSubForm.tsx
+++ b/src/components/AddressSubForm.tsx
@@ -19,22 +19,16 @@ interface AddressSubFormProps {
   register: UseFormRegister<IAddressSubForm>;
   errors: { [key in keyof IAddressSubForm]?: { message?: string } };
   onEdit: (data: IAddressSubForm) => void;
+  address: IAddressSubForm;
 }
 
-const AddressSubForm = ({ register, errors, onEdit }: AddressSubFormProps) => {
+const AddressSubForm = ({ register, errors, onEdit, address }: AddressSubFormProps) => {
   const [isEditing, setIsEditing] = useState(false);
-  const [editAddress, setEditAddress] = useState<IAddressSubForm>({
-    address1: '',
-    address2: '',
-    city: '',
-    state: '',
-    zipcode: '',
-    country: Country.USA,
-  });
+  const [editAddress, setEditAddress] = useState<IAddressSubForm>(address);
 
   const handleEditClick = () => {
     setIsEditing(true);
-    setEditAddress(register as unknown as IAddressSubForm);
+    setEditAddress(address);
   };
 
   const handleSaveClick = () => {

--- a/src/components/AddressSubForm.tsx
+++ b/src/components/AddressSubForm.tsx
@@ -17,11 +17,11 @@ export interface IAddressSubForm extends ICountryField {
 interface AddressSubFormProps {
   register: UseFormRegister<IAddressSubForm>;
   errors: { [key in keyof IAddressSubForm]?: { message?: string } };
-  onEdit: (data: IAddressSubForm) => void;
+  onSave: (data: IAddressSubForm) => void;
   address: IAddressSubForm;
 }
 
-const AddressSubForm = ({ register, errors, onEdit, address }: AddressSubFormProps) => {
+const AddressSubForm = ({ register, errors, onSave, address }: AddressSubFormProps) => {
   const [isEditing, setIsEditing] = useState(false);
   const [editAddress, setEditAddress] = useState<IAddressSubForm>(address);
 
@@ -31,7 +31,7 @@ const AddressSubForm = ({ register, errors, onEdit, address }: AddressSubFormPro
   };
 
   const handleSaveClick = () => {
-    onEdit(editAddress);
+    onSave(editAddress);
     setIsEditing(false);
   };
 

--- a/src/components/AddressSubForm.tsx
+++ b/src/components/AddressSubForm.tsx
@@ -1,0 +1,121 @@
+'use client';
+
+import { Country } from '@prisma/client';
+import React from 'react';
+import { Col, Container, Form, Row } from 'react-bootstrap';
+import { UseFormRegister } from 'react-hook-form';
+import CountryDropDown, { ICountryField } from '@/components/CountryDropDown';
+
+export interface IAddressSubForm extends ICountryField {
+  address1: string;
+  address2: string;
+  city: string;
+  state: string;
+  zipcode: string;
+}
+
+interface AddressSubFormProps {
+  register: UseFormRegister<IAddressSubForm>;
+  errors: { [key in keyof IAddressSubForm]?: { message?: string } };
+}
+
+const AddressSubForm = ({ register, errors }: AddressSubFormProps) => (
+  <Container>
+    <Row>
+      <Col md={6}>
+        <Form.Group controlId="address1">
+          <Form.Label aria-required="true">Address 1: *</Form.Label>
+          <Form.Control
+            id="address1"
+            type="text"
+            placeholder={'Address 1'}
+            size="lg"
+            isInvalid={!!errors.address1}
+            {...register('address1')}
+          />
+          <Form.Control.Feedback type="invalid">
+            {errors.address1?.message}
+          </Form.Control.Feedback>
+        </Form.Group>
+      </Col>
+    </Row>
+    <Row>
+      <Col md={6}>
+        <Form.Group controlId="address2">
+          <Form.Label>Address 2:</Form.Label>
+          <Form.Control
+            id="address2"
+            type="text"
+            placeholder={'Address 2'}
+            size="lg"
+            isInvalid={!!errors.address2}
+            {...register('address2')}
+          />
+          <Form.Control.Feedback type="invalid">
+            {errors.address2?.message}
+          </Form.Control.Feedback>
+        </Form.Group>
+      </Col>
+    </Row>
+    <Row>
+      <Col md={4}>
+        <Form.Group controlId="city">
+          <Form.Label>City:</Form.Label>
+          <Form.Control
+            id="city"
+            type="text"
+            placeholder={'City'}
+            size="lg"
+            isInvalid={!!errors.city}
+            {...register('city')}
+          />
+          <Form.Control.Feedback type="invalid">
+            {errors.city?.message}
+          </Form.Control.Feedback>
+        </Form.Group>
+      </Col>
+      <Col md={4}>
+        <Form.Group controlId="state">
+          <Form.Label>State:</Form.Label>
+          <Form.Control
+            id="state"
+            type="text"
+            placeholder={'State'}
+            size="lg"
+            isInvalid={!!errors.state}
+            {...register('state')}
+          />
+          <Form.Control.Feedback type="invalid">
+            {errors.state?.message}
+          </Form.Control.Feedback>
+        </Form.Group>
+      </Col>
+      <Col md={4}>
+        <Form.Group controlId="zipcode">
+          <Form.Label>Zipcode:</Form.Label>
+          <Form.Control
+            id="zipcode"
+            type="text"
+            placeholder={'Zipcode'}
+            size="lg"
+            isInvalid={!!errors.zipcode}
+            {...register('zipcode')}
+          />
+          <Form.Control.Feedback type="invalid">
+            {errors.zipcode?.message}
+          </Form.Control.Feedback>
+        </Form.Group>
+      </Col>
+    </Row>
+    <Row>
+      <Col md={4}>
+        <CountryDropDown
+          register={register('country') as unknown as UseFormRegister<ICountryField>}
+          errors={errors as unknown as { [key in keyof ICountryField]?: { message?: string } }}
+        />
+      </Col>
+    </Row>
+  </Container>
+);
+
+export default AddressSubForm;


### PR DESCRIPTION
This pull request introduces a new `AddressSubForm` React component to the codebase. The component provides an address input form with editing capabilities, integrated with `react-hook-form` and Bootstrap for validation and UI. It also supports country selection and error handling.

**New Address Form Component:**

* Added `AddressSubForm` component in `src/components/AddressSubForm.tsx`, allowing users to view, edit, and save address information with validation and error feedback.
* Integrated `CountryDropDown` for country selection, supporting type safety and error handling for country fields.
* Implemented UI controls for editing, saving, and canceling address changes using Bootstrap buttons and icons (`Pencil`, `Check`, `X`).
* Utilized `react-hook-form` for form registration and validation, passing errors and register methods as props.
closes #178